### PR TITLE
Update react-06.md

### DIFF
--- a/content/tutorial-react/react-06.md
+++ b/content/tutorial-react/react-06.md
@@ -166,7 +166,7 @@ This results in the two new props `updatePokemon` and `deletePokemon`, so let's 
 
 ```js@src/components/PokemonCard.js
 static propTypes = {
-  pokemon: PokemonCard.fragments.pokemon.propType,
+  pokemon: propType(PokemonCard.fragments.pokemon).isRequired,
   handleCancel: React.PropTypes.func.isRequired,
   afterChange: React.PropTypes.func.isRequired,
   updatePokemon: React.PropTypes.func.isRequired,


### PR DESCRIPTION
Error appears in console and this commit fix it.
I think that probably propType from `graphql-anywhere` should be used as before, please correct me if I'm wrong.

```
Warning: Failed prop type: PokemonCard: prop type `pokemon` is invalid; it must be a function, usually from React.PropTypes.
    in PokemonCard (created by Apollo(PokemonCard))
    in Apollo(PokemonCard) (created by Apollo(Apollo(PokemonCard)))
    in Apollo(Apollo(PokemonCard)) (created by PokemonPage)
    in div (created by PokemonPage)
    in PokemonPage (created by withRouter(PokemonPage))
    in withRouter(PokemonPage) (created by Apollo(withRouter(PokemonPage)))
    in Apollo(withRouter(PokemonPage)) (created by RouterContext)
    in RouterContext (created by Router)
    in Router
    in ApolloProvider
```