### PR TITLE
Pass mutate to component

### DIFF
--- a/content/excursions/excursion-02.md
+++ b/content/excursions/excursion-02.md
@@ -97,6 +97,7 @@ const AddPokemonCardWithMutation = graphql(createPokemonMutation, {
           },
         })
       },
+      mutate,
     }
   },
 })(withRouter(AddPokemonCard))


### PR DESCRIPTION
We need to return mutate otherwise the component doesn't have access to the function and the app complains (based on the exercise-05, if we try to apply what we learn in excursion-02).