### PR TITLE
Update the npm start command to npm run dev

### DIFF
--- a/content/tutorial-vue/vue-playground.md
+++ b/content/tutorial-vue/vue-playground.md
@@ -15,6 +15,6 @@ Run the application:
 ```sh
 cd pokedex-vue-master/playground
 yarn install # or npm install
-yarn start # or npm run dev
+yarn run dev # or npm run dev
 # open localhost:3000
 ```

--- a/content/tutorial-vue/vue-playground.md
+++ b/content/tutorial-vue/vue-playground.md
@@ -15,6 +15,6 @@ Run the application:
 ```sh
 cd pokedex-vue-master/playground
 yarn install # or npm install
-yarn start # or npm start
+yarn start # or npm run dev
 # open localhost:3000
 ```


### PR DESCRIPTION
The json file shows the command as "dev" not "start", which will cause "Start script missing error". So, it should written "npm run dev" instead "npm install".
Or.. am I missing something?